### PR TITLE
Accept generic observers in model

### DIFF
--- a/src/pixelcraft/PCModel.java
+++ b/src/pixelcraft/PCModel.java
@@ -50,8 +50,8 @@ public class PCModel {
         return redoStack;
     }
 
-    public void addObserver(PCView view) {
-        observers.add(view);
+    public void addObserver(Observer observer) {
+        observers.add(observer);
         this.notifyObservers("observer added");
     }
 

--- a/src/pixelcraft/PixelCraftGUI.java
+++ b/src/pixelcraft/PixelCraftGUI.java
@@ -9,10 +9,10 @@ public class PixelCraftGUI extends Application {
     public void start(Stage stage) {
 
         PCModel model = new PCModel();
-        PCView view = new PCView(stage);
+        Observer view = new PCView(stage);
         model.addObserver(view);
 
-        PCController controller = new PCController(model, view);
+        PCController controller = new PCController(model, (PCView) view);
         controller.installControllers();
     }
 


### PR DESCRIPTION
## Summary
- Broaden `PCModel.addObserver` to accept any `Observer` implementation
- Adjust `PixelCraftGUI` to pass observers compatible with the new signature

## Testing
- `javac $(find src -name "*.java")` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a226e546f8832a98c9e91049764955