### PR TITLE
Refactor file IO and history management

### DIFF
--- a/src/pixelcraft/HistoryManager.java
+++ b/src/pixelcraft/HistoryManager.java
@@ -1,0 +1,45 @@
+package pixelcraft;
+
+import javafx.scene.image.Image;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class HistoryManager {
+    private final Deque<HistoryEntry> undoStack = new ArrayDeque<>();
+    private final Deque<HistoryEntry> redoStack = new ArrayDeque<>();
+    private final int historyLimit = 5;
+
+    public Deque<HistoryEntry> getUndoStack() {
+        return undoStack;
+    }
+
+    public Deque<HistoryEntry> getRedoStack() {
+        return redoStack;
+    }
+
+    public void clearHistory() {
+        redoStack.clear();
+        undoStack.clear();
+    }
+
+    public void recordState(Image image, boolean dirty) {
+        pushBounded(undoStack, new HistoryEntry(image, dirty));
+    }
+
+    public HistoryEntry undo(Image currentImage, boolean dirty) {
+        redoStack.push(new HistoryEntry(currentImage, dirty));
+        return undoStack.pop();
+    }
+
+    public HistoryEntry redo(Image currentImage, boolean dirty) {
+        undoStack.push(new HistoryEntry(currentImage, dirty));
+        return redoStack.pop();
+    }
+
+    private void pushBounded(Deque<HistoryEntry> stack, HistoryEntry entry) {
+        if (stack.size() >= historyLimit) {
+            stack.removeLast();
+        }
+        stack.push(entry);
+    }
+}

--- a/src/pixelcraft/ImageIOService.java
+++ b/src/pixelcraft/ImageIOService.java
@@ -1,0 +1,49 @@
+package pixelcraft;
+
+import javafx.scene.image.Image;
+import javafx.scene.image.PixelReader;
+import javafx.scene.image.PixelWriter;
+import javafx.scene.image.WritableImage;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class ImageIOService {
+    public static Image loadImage(String filePath) throws IOException {
+        try (FileInputStream inputFile = new FileInputStream(new File(filePath))) {
+            Image img = new Image(inputFile);
+            if (img.isError()) {
+                throw new IOException("Decode error: " + img.getException());
+            }
+            return deepCopyImage(img);
+        }
+    }
+
+    public static void saveImage(Image image, String filePath) throws IOException {
+        int width = (int) image.getWidth();
+        int height = (int) image.getHeight();
+
+        PixelReader pixelReader = image.getPixelReader();
+        BufferedImage bufferedImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                bufferedImage.setRGB(x, y, pixelReader.getArgb(x, y));
+            }
+        }
+        ImageIO.write(bufferedImage, "png", new File(filePath));
+    }
+
+    public static Image deepCopyImage(Image src) {
+        int w = (int) src.getWidth();
+        int h = (int) src.getHeight();
+
+        WritableImage output = new WritableImage(w, h);
+        PixelReader pr = src.getPixelReader();
+        PixelWriter pw = output.getPixelWriter();
+        pw.setPixels(0, 0, w, h, pr, 0, 0);
+        return output;
+    }
+}

--- a/src/pixelcraft/PCModel.java
+++ b/src/pixelcraft/PCModel.java
@@ -1,15 +1,7 @@
 package pixelcraft;
 
 import javafx.scene.image.Image;
-import javafx.scene.image.PixelReader;
-import javafx.scene.image.PixelWriter;
-import javafx.scene.image.WritableImage;
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 
@@ -18,12 +10,11 @@ public class PCModel {
     private Image originalImage;
     private Image currentImage;
     private boolean dirty = false;
-    private final Deque<HistoryEntry> undoStack = new ArrayDeque<>();
-    private final Deque<HistoryEntry> redoStack = new ArrayDeque<>();
-    private final int historyLimit = 5;
+    private final HistoryManager historyManager;
 
     public PCModel() {
         observers = new ArrayList<>();
+        historyManager = new HistoryManager();
     }
 
     public Image getImage() {
@@ -43,11 +34,11 @@ public class PCModel {
     }
 
     public Deque<HistoryEntry> getUndoStack() {
-        return undoStack;
+        return historyManager.getUndoStack();
     }
 
     public Deque<HistoryEntry> getRedoStack() {
-        return redoStack;
+        return historyManager.getRedoStack();
     }
 
     public void addObserver(Observer observer) {
@@ -62,15 +53,10 @@ public class PCModel {
     }
 
     public void loadFromFile(String filePath) {
-        try (FileInputStream inputFile = new FileInputStream(new File(filePath))) {
-            Image img = new Image(inputFile);
-            if (img.isError()) {
-                System.err.println("Decode error: " + img.getException());
-                notifyObservers("ERROR: decode");
-                return;
-            }
-            this.originalImage = deepCopyImage(img);
-            this.currentImage = deepCopyImage(img);
+        try {
+            Image img = ImageIOService.loadImage(filePath);
+            this.originalImage = ImageIOService.deepCopyImage(img);
+            this.currentImage = ImageIOService.deepCopyImage(img);
             this.dirty = false;
             this.clearHistory();
             Pixelate.resetCycle();
@@ -82,27 +68,18 @@ public class PCModel {
     }
 
     public void clearHistory() {
-        redoStack.clear();
-        undoStack.clear();
-    };
+        historyManager.clearHistory();
+    }
 
 
     public void resetToOriginal() {
         if (originalImage == null) return;
-        redoStack.clear();
-        HistoryEntry historyEntry = new HistoryEntry(deepCopyImage(currentImage), dirty);
-        pushBounded(undoStack, historyEntry);
+        historyManager.getRedoStack().clear();
+        historyManager.recordState(ImageIOService.deepCopyImage(currentImage), dirty);
         this.currentImage = originalImage;
         this.dirty = false;
         Pixelate.resetCycle();
         notifyObservers("IMAGE_RESET");
-    }
-
-    private void pushBounded(Deque<HistoryEntry> stack, HistoryEntry entry) {
-        if (stack.size() >= historyLimit) {
-            stack.removeLast();
-        }
-        stack.push(entry);
     }
 
     public void apply(Converter converter) {
@@ -112,40 +89,24 @@ public class PCModel {
             notifyObservers("ERROR: convert");
             return;
         };
-        redoStack.clear();
-        HistoryEntry historyEntry = new HistoryEntry(deepCopyImage(currentImage), dirty);
-        pushBounded(undoStack, historyEntry);
+        historyManager.getRedoStack().clear();
+        historyManager.recordState(ImageIOService.deepCopyImage(currentImage), dirty);
         this.currentImage = next;
         this.dirty = true;
         notifyObservers("IMAGE_CHANGED");
     }
 
-    private Image deepCopyImage(Image src) {
-        int w = (int) src.getWidth();
-        int h = (int) src.getHeight();
-
-        WritableImage output = new WritableImage(w, h);
-        PixelReader pr = src.getPixelReader();
-        PixelWriter pw = output.getPixelWriter();
-        pw.setPixels(0, 0, w, h, pr, 0, 0);
-        return output;
-    }
-
     public void undo() {
-        if (undoStack.isEmpty()) return;
-        HistoryEntry historyEntry = new HistoryEntry(deepCopyImage(currentImage), dirty);
-        redoStack.push(historyEntry);
-        HistoryEntry e = undoStack.pop();
+        if (historyManager.getUndoStack().isEmpty()) return;
+        HistoryEntry e = historyManager.undo(ImageIOService.deepCopyImage(currentImage), dirty);
         this.currentImage = e.getImage();
         this.dirty = e.isDirty();
         notifyObservers("undo");
     }
 
     public void redo() {
-        if (redoStack.isEmpty()) return;
-        HistoryEntry historyEntry = new HistoryEntry(deepCopyImage(currentImage), dirty);
-        undoStack.push(historyEntry);
-        HistoryEntry e = redoStack.pop();
+        if (historyManager.getRedoStack().isEmpty()) return;
+        HistoryEntry e = historyManager.redo(ImageIOService.deepCopyImage(currentImage), dirty);
         this.currentImage = e.getImage();
         this.dirty = e.isDirty();
         notifyObservers("redo");
@@ -154,41 +115,11 @@ public class PCModel {
     public void saveCurrentImage(String filePath) {
         if (currentImage == null) return;
         try {
-            saveImage(this.getImage(), filePath);
+            ImageIOService.saveImage(this.getImage(), filePath);
             notifyObservers("IMAGE_SAVED");
         } catch (IOException e) {
             System.err.println("I/O error: " + e.getMessage());
             notifyObservers("ERROR: io");
-        }
-    }
-
-    public void saveImage(Image image, String filePath) throws IOException {
-
-        int width = (int) image.getWidth();
-        int height = (int) image.getHeight();
-
-        // Create a writable image
-        WritableImage writableImage = new WritableImage(width, height);
-
-        // Get the pixel reader from the original image
-        PixelReader pixelReader = image.getPixelReader();
-
-        // Create a BufferedImage
-        BufferedImage bufferedImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-
-        // Copy the pixels to the BufferedImage
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                bufferedImage.setRGB(x, y, pixelReader.getArgb(x, y));
-            }
-        }
-
-        // Save the BufferedImage as PNG
-        try {
-            ImageIO.write(bufferedImage, "png", new File(filePath));
-            System.out.println("Image saved successfully.");
-        } catch (IOException e) {
-            System.err.println("Error saving image: " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extract file loading and saving logic into new `ImageIOService`
- Add `HistoryManager` to handle undo/redo stacks
- Streamline `PCModel` to delegate IO and history tasks

## Testing
- `javac @sources.txt` *(fails: package javafx.scene.image does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a2324c9728832a9f920c3179c31557