### PR TITLE
Improve method organization for readability

### DIFF
--- a/src/pixelcraft/PCModel.java
+++ b/src/pixelcraft/PCModel.java
@@ -35,6 +35,10 @@ public class PCModel {
         return historyManager.getRedoStack();
     }
 
+    public int getPixelBlockSize() {
+        return pixelBlockSize;
+    }
+
     public void addObserver(Observer observer) {
         observers.add(observer);
         this.notifyObservers("observer added");
@@ -133,7 +137,4 @@ public class PCModel {
         }
     }
 
-    public int getPixelBlockSize() {
-        return pixelBlockSize;
-    }
 }

--- a/src/pixelcraft/PCView.java
+++ b/src/pixelcraft/PCView.java
@@ -60,26 +60,6 @@ public class PCView implements Observer {
         stage.show();
     }
 
-    // Arrange buttons and image view.
-    private void buildUI() {
-        VBox vBox = new VBox(10, btnOpen, btnSave, btnReset, new Separator(),
-                btnGrayscale, btnRotate, btnBlur, btnFlipH, btnFlipV, btnMirror,
-                btnPixelate, btnSepia, btnInvert);
-        vBox.setPadding(new Insets(10));
-        vBox.setFillWidth(true);
-        vBox.getStyleClass().add("toolbox");
-
-        HBox hBox = new HBox(5, btnUndo, btnRedo);
-        hBox.setPadding(new Insets(10));
-        hBox.getStyleClass().add("toolbox");
-        hBox.setAlignment(Pos.CENTER);
-
-        pane.setLeft(vBox);
-        pane.setTop(hBox);
-        pane.setCenter(imageView);
-    }
-    
-
     public Stage getStage() { return stage; }
     public BorderPane getPane() { return pane; }
     public ImageView getImageView() { return imageView; }
@@ -99,6 +79,31 @@ public class PCView implements Observer {
     public Button getBtnPixelate() { return btnPixelate; }
     public Button getBtnSepia() { return btnSepia; }
     public Button getBtnInvert() { return btnInvert; }
+
+    // Observer callback: refresh the view.
+    public void update(PCModel model, String message) {
+        imageView.setImage(model.getImage());
+        updateButtonStates(model);
+    }
+
+    // Arrange buttons and image view.
+    private void buildUI() {
+        VBox vBox = new VBox(10, btnOpen, btnSave, btnReset, new Separator(),
+                btnGrayscale, btnRotate, btnBlur, btnFlipH, btnFlipV, btnMirror,
+                btnPixelate, btnSepia, btnInvert);
+        vBox.setPadding(new Insets(10));
+        vBox.setFillWidth(true);
+        vBox.getStyleClass().add("toolbox");
+
+        HBox hBox = new HBox(5, btnUndo, btnRedo);
+        hBox.setPadding(new Insets(10));
+        hBox.getStyleClass().add("toolbox");
+        hBox.setAlignment(Pos.CENTER);
+
+        pane.setLeft(vBox);
+        pane.setTop(hBox);
+        pane.setCenter(imageView);
+    }
 
     // Disable buttons until an image is loaded.
     private void setInitialDisabledState() {
@@ -149,11 +154,5 @@ public class PCView implements Observer {
         btnSave.setDisable(!canSave);
         btnUndo.setDisable(!canUndo);
         btnRedo.setDisable(!canRedo);
-    }
-
-    // Observer callback: refresh the view.
-    public void update(PCModel model, String message) {
-        imageView.setImage(model.getImage());
-        updateButtonStates(model);
     }
 }


### PR DESCRIPTION
## Summary
- Grouped PCModel getters together by moving `getPixelBlockSize` with other accessor methods
- Reordered PCView to place public accessors and observer update before private helper methods

## Testing
- `javac src/pixelcraft/*.java` *(fails: package javafx.scene.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a27618af58832a9a98e1f22ea9549f